### PR TITLE
Update to Distribution v2.8

### DIFF
--- a/lib/src/main/java/de/gesellix/docker/registry/DockerRegistry.java
+++ b/lib/src/main/java/de/gesellix/docker/registry/DockerRegistry.java
@@ -36,13 +36,14 @@ public class DockerRegistry {
     this.imageApi = new ImageApi(dockerClientConfig);
 
     if (LocalDocker.isNativeWindows()) {
-      imageNameWithTag = "gesellix/registry:2.7.1-windows-ltsc2022";
+      imageNameWithTag = "gesellix/registry:2.8.1-windows-ltsc2022";
+//      imageNameWithTag = "gesellix/registry:2.7.1-windows-ltsc2022";
 //      imageNameWithTag = "gesellix/registry:2.7.1-windows-ltsc2019";
 //      imageNameWithTag = "gesellix/registry:2.7.1-windows-1809";
 //      imageNameWithTag = "gesellix/registry:2.7.1-windows";
     }
     else {
-      imageNameWithTag = "registry:2.8";
+      imageNameWithTag = "registry:2.8.1";
     }
   }
 

--- a/registry-windows/Dockerfile
+++ b/registry-windows/Dockerfile
@@ -1,17 +1,20 @@
-# https://github.com/golang/go/issues/35447
-FROM golang:1.12 as build
+FROM golang:1.16.15 AS build
+#FROM golang:1.16.15-nanoserver AS build
+
+ENV GO111MODULE=auto
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV DOCKER_BUILDTAGS include_oss include_gcs
-ENV DISTRIBUTION_VERSION v2.7.1
+ENV DISTRIBUTION_VERSION v2.8.1
 
 RUN mkdir src\github.com\docker ; \
     cd src\github.com\docker ; \
     git clone -q https://github.com/docker/distribution ; \
     cd distribution ; \
     git checkout -q $env:DISTRIBUTION_VERSION ; \
-    go build -o registry.exe cmd/registry/main.go
+    cd cmd\registry ; \
+    go build -o registry.exe
 
 FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
 #FROM mcr.microsoft.com/windows/servercore:ltsc2019
@@ -22,5 +25,5 @@ EXPOSE 5000
 ENTRYPOINT ["\\registry.exe"]
 CMD ["serve", "/config/config.yml"]
 
-COPY --from=build /gopath/src/github.com/docker/distribution/registry.exe /registry.exe
+COPY --from=build /gopath/src/github.com/docker/distribution/cmd/registry/registry.exe /registry.exe
 COPY config.yml /config/config.yml

--- a/registry-windows/README.md
+++ b/registry-windows/README.md
@@ -1,7 +1,7 @@
 Inspiration from:
 
 https://github.com/sixeyed/dockerfiles-windows/blob/master/registry/nanoserver/1809/Dockerfile
-https://github.com/StefanScherer/dockerfiles-windows/blob/master/registry/Dockerfile
+https://github.com/StefanScherer/dockerfiles-windows/blob/main/registry/Dockerfile
 
 https://github.com/docker/distribution-library-image/pull/42
 


### PR DESCRIPTION
See https://github.com/distribution/distribution/releases/tag/v2.8.1

- [x] Linux/Mac (official image from registry:2.8.1)
- [x] Windows (see #3)
