### PR TITLE
Require okio >= 3.x

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     ).onEach {
       implementation(it) {
         version {
-          strictly("[1.6,1.7)")
+          strictly("[1.5,1.7)")
           prefer("1.6.21")
         }
       }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -33,10 +33,15 @@ dependencies {
         }
       }
     }
-    implementation("com.squareup.okio:okio") {
-      version {
-        strictly("[2.5,4)")
-        prefer("3.1.0")
+    listOf(
+      "com.squareup.okio:okio",
+      "com.squareup.okio:okio-jvm"
+    ).forEach {
+      implementation(it) {
+        version {
+          strictly("[3,4)")
+          prefer("3.1.0")
+        }
       }
     }
   }


### PR DESCRIPTION
Explicitly using okio-jvm makes the artifacts Maven-compatible.

Relates to https://github.com/gesellix/docker-client/issues/245