### PR TITLE
Update READMEs for the multi-arch registry image

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,35 @@
 
 # docker-registry
 
-*TODO*: automatically create multiarch images for:
+## Container images
 
-- Linux
-- Windows
+Multi-arch [Docker distribution/registry](https://github.com/distribution/distribution)
+images are published to Docker Hub as `gesellix/registry`. Each tag is a single
+manifest spanning:
 
-  A container's base image OS must match the host's OS: https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility?tabs=windows-server-1909%2Cwindows-10-1909
+- `linux/amd64`, `linux/arm64`
+- Windows nanoserver `ltsc2022` and `ltsc2025` (amd64)
 
-  Otherwise we'll get error messages like this when trying to run an image with the wrong base image OS:
+They are built by the `Build and Push multi-arch image` workflow
+(`.github/workflows/image.yml`), triggered manually via `workflow_dispatch` with an
+`image_tag` input. The Linux images are built from `registry-windows/Dockerfile.linux`
+(cross-compiled via buildx), the Windows images from `registry-windows/Dockerfile`
+(built natively on the matching Windows runner). Both compile the registry from source
+with the `include_oss include_gcs` build tags.
 
-  > The container operating system does not match the host operating system
+When running a Windows image, the container's base image OS must match the host's OS, see
+[version compatibility](https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility?tabs=windows-server-1909%2Cwindows-10-1909).
+Otherwise you get errors like this when trying to run an image with the wrong base image OS:
 
-  See https://github.com/olljanat/multi-win-version-aspnet for an example of creating Windows multiarch images (source: https://github.com/moby/moby/issues/35247#issuecomment-436634221).
+> The container operating system does not match the host operating system
+
+The multi-arch manifest handles this automatically: a host pulls the variant matching its
+own OS and architecture (the Windows entries carry distinct `os.version` values for
+`ltsc2022` vs `ltsc2025`).
+
+### References
+
+- [olljanat/multi-win-version-aspnet](https://github.com/olljanat/multi-win-version-aspnet): example of creating Windows multiarch images (source: [moby/moby#35247](https://github.com/moby/moby/issues/35247#issuecomment-436634221)).
 
 ## Publishing/Release Workflow
 

--- a/registry-windows/README.md
+++ b/registry-windows/README.md
@@ -1,8 +1,22 @@
-Inspiration from:
+# registry-windows
 
-https://github.com/sixeyed/dockerfiles-windows/blob/master/registry/nanoserver/1809/Dockerfile
-https://github.com/StefanScherer/dockerfiles-windows/blob/main/registry/Dockerfile
+Dockerfiles that build the [Docker distribution/registry](https://github.com/distribution/distribution)
+from source with the `include_oss include_gcs` build tags. The shared `config.yml` is used
+by both variants.
 
-https://github.com/docker/distribution-library-image/pull/42
+- `Dockerfile`: Windows nanoserver image. Built natively on a Windows runner; the build
+  stage uses `golang:<ver>-windowsservercore-<WINDOWS_VERSION>` (servercore ships git and
+  PowerShell), the runtime stage `mcr.microsoft.com/windows/nanoserver:<WINDOWS_VERSION>`.
+  The Windows base is selected with the `WINDOWS_VERSION` build arg (`ltsc2022`, `ltsc2025`).
+- `Dockerfile.linux`: Linux image (alpine runtime), cross-compiled per target arch via
+  buildx (`TARGETOS` / `TARGETARCH`).
 
-https://github.com/docker/distribution/pull/2281
+Both are wired into the `Build and Push multi-arch image` workflow
+(`../.github/workflows/image.yml`), which publishes the combined `gesellix/registry` manifest.
+
+## Inspiration / references
+
+- https://github.com/sixeyed/dockerfiles-windows/blob/master/registry/nanoserver/1809/Dockerfile
+- https://github.com/StefanScherer/dockerfiles-windows/blob/main/registry/Dockerfile
+- https://github.com/docker/distribution-library-image/pull/42
+- https://github.com/docker/distribution/pull/2281


### PR DESCRIPTION
The "automatically create multiarch images for Linux + Windows" TODO is done, so document the published gesellix/registry manifest and how it is built instead of describing it as future work.

- Top-level README: describe the multi-arch images, the image.yml workflow and the two Dockerfiles; keep the OS-match note and the historic version compatibility / olljanat / moby#35247 reference links.
- registry-windows README: explain both Dockerfiles (Windows servercore build + nanoserver runtime, Linux cross-compile) and the WINDOWS_VERSION arg; retain the original inspiration links.