### PR TITLE
Use the multi-arch gesellix/registry image

### DIFF
--- a/lib/src/main/java/de/gesellix/docker/registry/DockerRegistry.java
+++ b/lib/src/main/java/de/gesellix/docker/registry/DockerRegistry.java
@@ -36,12 +36,8 @@ public class DockerRegistry {
     this.containerApi = new ContainerApi(dockerClientConfig);
     this.imageApi = new ImageApi(dockerClientConfig);
 
-    if (LocalDocker.isNativeWindows()) {
-      imageNameWithTag = "gesellix/registry:3.1.1-windows-ltsc2022";
-    } else {
-      imageNameWithTag = "registry:3.1.1";
-    }
-    imageNameWithTag = System.getProperty("DOCKER_REGISTRY_IMAGE_OVERRIDE", imageNameWithTag);
+    final String defaultImageNameWithTag = "gesellix/registry:3.1.1";
+    imageNameWithTag = System.getProperty("DOCKER_REGISTRY_IMAGE_OVERRIDE", defaultImageNameWithTag);
   }
 
   public void setImageNameWithTag(String imageNameWithTag) {


### PR DESCRIPTION
Now that `gesellix/registry:<tag>` is published as a single multi-arch manifest (linux/amd64, linux/arm64, Windows ltsc2022 + ltsc2025) by the `image.yml` workflow, `DockerRegistry` no longer needs to branch on the host OS.

## Changes
- Drop the `LocalDocker.isNativeWindows()` branching that picked between `gesellix/registry:3.1.1-windows-ltsc2022` and `registry:3.1.1`.
- Use the single `gesellix/registry:3.1.1` manifest for every platform; the daemon pulls the variant matching its own OS and architecture.
- The `DOCKER_REGISTRY_IMAGE_OVERRIDE` system property still overrides the default.

## Notes
- `LocalDocker.isNativeWindows()` is now unused (only `available()` is still referenced, by the test). Left in place; can be removed in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)