### PR TITLE
Disable OTel traces export

### DIFF
--- a/lib/src/main/java/de/gesellix/docker/registry/DockerRegistry.java
+++ b/lib/src/main/java/de/gesellix/docker/registry/DockerRegistry.java
@@ -1,7 +1,7 @@
 package de.gesellix.docker.registry;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonList;
 
 import java.util.HashMap;
 import java.util.List;
@@ -51,7 +51,9 @@ public class DockerRegistry {
   public void run() {
     ContainerCreateRequest containerConfig = new ContainerCreateRequest();
     containerConfig.setImage(getImageNameWithTag());
-    containerConfig.setEnv(singletonList("REGISTRY_VALIDATION_DISABLED=true"));
+    containerConfig.setEnv(asList(
+        "REGISTRY_VALIDATION_DISABLED=true",
+        "OTEL_TRACES_EXPORTER=none"));
     Map<String, Object> exposedPorts = new HashMap<>();
     exposedPorts.put("5000/tcp", emptyMap());
     containerConfig.setExposedPorts(exposedPorts);

--- a/registry-windows/Dockerfile.linux
+++ b/registry-windows/Dockerfile.linux
@@ -22,8 +22,11 @@ RUN mkdir -p src/github.com/distribution \
 FROM alpine:3.24.0
 EXPOSE 5000
 
-ENTRYPOINT ["/registry"]
+# Note: the registry binary must NOT live at /registry, because config.yml
+# configures the filesystem storage rootdirectory as /registry. Placing the
+# binary there would make every storage access fail with ENOTDIR (HTTP 500).
+ENTRYPOINT ["/bin/registry"]
 CMD ["serve", "/config/config.yml"]
 
-COPY --from=build /registry /registry
+COPY --from=build /registry /bin/registry
 COPY config.yml /config/config.yml


### PR DESCRIPTION
See https://distribution.github.io/distribution/about/configuration/#disable-traces-export

Also fixes the Linux image to keep the storage directory at `/registry` available.
